### PR TITLE
Recover event subscriptions after a player power-cycle (re-subscribe + UUID addressing)

### DIFF
--- a/src/Discovery.js
+++ b/src/Discovery.js
@@ -1,14 +1,14 @@
 /**
- * Collection of methods to handle the discovery of player. 
- * Method: UDP SSD broadcast port 1900.
+ * Collection of methods to handle the discovery of player.
+ * Method: UDP SSDP broadcast port 1900.
  * Part of SONOS-plus.
  *
  * @module Discovery
- * 
+ *
  * @author Henning Klages
- * 
+ *
  * @since 2023-01-05
- * 
+ *
 */
 
 'use strict'
@@ -21,40 +21,68 @@ const SonosPlayerDiscovery   = require('./Discovery-base-hk.js')
 
 const debug = require('debug')(`${PACKAGE_PREFIX}discovery`)
 
-module.exports = {
-  
-  // copy from SONOS-plus 2023-01-05
+/** SSDP-discover one player, then enumerate the whole household from it.
+ * Discovering the first one and asking it for the rest is reliable/deterministic.
+ * @returns {Promise<object[]>} flat list of members ({urlObject, playerName, uuid, ...})
+ * @throws {error} all methods
+ */
+async function discoverFlatList () {
+  const deviceDiscovery = new SonosPlayerDiscovery()
+  const firstPlayerIpv4 = await deviceDiscovery.discoverOnePlayer()
+  debug('first player found >>%s', firstPlayerIpv4)
+  const firstPlayer = new SonosDevice(firstPlayerIpv4)
+  const allGroups = await getGroupsAll(firstPlayer)
+  const flatList = [].concat.apply([], allGroups)
+  debug('got players, in total >>%s', flatList.length)
+  return flatList
+}
 
-  /** Does an async discovery of SONOS player and returns list of objects
-   * with properties label and value including the IP address = host.
-   * 
-   * 
-   * @returns {Promise<object>} {'label', value}
-   * 
+module.exports = {
+
+  /** Discover all players, returns list of {label, value} with value = ip host.
+   * @returns {Promise<object[]>} {'label', value}
    * @throws {error} all methods
-   * 
-   * Hint: discover the first one and retrieves all other player from that player.
-   * Thats very reliable -deterministic. 
-   * Discovering 10 player or more might be time consuming in some networks.
    */
   discoverAllPlayerWithHost: async () => {
     debug('method:%s', 'discoverAllPlayerWithHost')
-    
-    const deviceDiscovery = new SonosPlayerDiscovery()
-    const firstPlayerIpv4 = await deviceDiscovery.discoverOnePlayer()
-    debug('first player found')
-    const firstPlayer = new SonosDevice(firstPlayerIpv4)
-    const allGroups = await getGroupsAll(firstPlayer)
-    const flatList = [].concat.apply([], allGroups)
-    debug('got more players, in total >>%s', flatList.length)
-
-    const reducedList = flatList.map((item) => {
+    const flatList = await discoverFlatList()
+    return flatList.map((item) => {
       return {
         'label': `${item.urlObject.hostname} for ${item.playerName}`,
         'value': item.urlObject.hostname
       }
     })
-    return reducedList
+  },
+
+  /** Discover all zones, returns list of {label, value, uuid, host, playerName}
+   * with value = durable uuid (for persisting a selection that survives IP changes).
+   * @returns {Promise<object[]>}
+   * @throws {error} all methods
+   */
+  discoverAllZones: async () => {
+    debug('method:%s', 'discoverAllZones')
+    const flatList = await discoverFlatList()
+    return flatList.map((item) => {
+      return {
+        'label': `${item.playerName} (${item.urlObject.hostname})`,
+        'value': item.uuid,
+        'uuid': item.uuid,
+        'host': item.urlObject.hostname,
+        'playerName': item.playerName
+      }
+    })
+  },
+
+  /** Resolve a durable uuid to its current ip host via discovery.
+   * @param {string} uuid the player RINCON uuid
+   * @returns {Promise<string|null>} current ip host, or null if not on the network
+   * @throws {error} discovery methods (e.g. no players found)
+   */
+  discoverIpByUuid: async (uuid) => {
+    debug('method:%s', 'discoverIpByUuid')
+    const flatList = await discoverFlatList()
+    const found = flatList.find((item) => item.uuid === uuid)
+    return (found ? found.urlObject.hostname : null)
   }
-    
+
 }

--- a/src/sonosevents-config.js
+++ b/src/sonosevents-config.js
@@ -19,7 +19,7 @@
 
 const { PACKAGE_PREFIX, TIMEOUT_PLAYER_DISCOVERY } = require('./Globals.js')
 
-const { discoverAllPlayerWithHost } = require('./Discovery.js')
+const { discoverAllPlayerWithHost, discoverAllZones } = require('./Discovery.js')
 
 const { getRightCcuIp, getMultipleIps } = require('./Extensions.js')
 
@@ -83,6 +83,20 @@ module.exports = function (RED) {
         })
       break
       
+    case 'discoverAllZones':
+      debug('starting zone discovery')
+      discoverAllZones()
+        .then((zoneList) => { response.json(zoneList) })
+        .catch((error) => {
+          if (isTruthyProperty(error, ['message']) && error.message === TIMEOUT_PLAYER_DISCOVERY) {
+            response.json([{ 'label': 'no players found', 'value': '' }])
+            return
+          }
+          debug('error zone discovery >>%s', JSON.stringify(error, Object.getOwnPropertyNames(error)))
+          response.json([])
+        })
+      break
+
     case 'getIp':
       getRightCcuIp(0)
         .then((ipList) => {

--- a/src/sonosevents-selection.html
+++ b/src/sonosevents-selection.html
@@ -27,12 +27,16 @@
       },
       outputs: {
         value: 2
+      },
+      refreshSeconds: {
+        value: 60,
+        validate: RED.validators.number()
       }
     },
     outputLabels: function (i) {
       return this.events[i].fullName
     },
-    inputs: 0, // set the number of inputs - only 0 or 1
+    inputs: 1, // set the number of inputs - only 0 or 1 (input forces re-subscribe)
     icon: 'sonos.png', // saved in icons/myicon.png
     color: '#FDD4AA',
     paletteLabel: 'events',
@@ -205,6 +209,16 @@
 <div class="form-row">
   <input type="hidden" id="node-input-outputs" />
 </div>
+
+<!-- Refresh / re-subscribe interval -->
+<div class="form-row">
+  <label for="node-input-refreshSeconds" style="width: 30%;"><i class="fa fa-refresh"></i> Refresh (s)</label>
+  <input type="number" id="node-input-refreshSeconds" placeholder="60" style="width: 80px;">
+</div>
+<div class="form-tips">
+  <b>Refresh</b>: how often (seconds) to renew the event subscription. A renewal after the
+  player power-cycles forces a fresh re-subscribe, so events resume within this interval.
+</div><br>
 
 <!-- Node name -->
 <div class="form-row">

--- a/src/sonosevents-selection.html
+++ b/src/sonosevents-selection.html
@@ -12,8 +12,13 @@
         type: 'sonosevents-config'
       },
       playerHostname: {
-        value: '',
-        required: true
+        value: ''
+      },
+      playerUuid: {
+        value: ''
+      },
+      playerName: {
+        value: ''
       },
       events: {
         value: [{ fullName: 'AVTransportService.playbackstate' }, { fullName: 'AVTransportService.content' }],
@@ -41,10 +46,38 @@
     color: '#FDD4AA',
     paletteLabel: 'events',
     label: function () {
-      let nodeLabel = this.name || `${this.playerHostname} events`
-      return nodeLabel
+      return this.name || (this.playerName ? `${this.playerName} events` : `${this.playerHostname} events`)
     },
     oneditprepare: function () {
+
+      // zone select (durable uuid). discover and select a zone, or leave empty
+      // to fall back to the IP/hostname field below.
+      const $zone = $('#node-input-playerUuid')
+      $zone.empty()
+      $zone.append($('<option>').val('').text('-- use IP/hostname below --'))
+      if (this.playerUuid) {
+        $zone.append($('<option>').val(this.playerUuid).attr('data-playername', this.playerName || '').text(this.playerName || this.playerUuid))
+        $zone.val(this.playerUuid)
+      }
+      $zone.on('change', function () {
+        $('#node-input-playerName').val($('#node-input-playerUuid option:selected').attr('data-playername') || '')
+      })
+      $('#node-lookup-zones').click(function () {
+        $('#node-lookup-zones-icon').removeClass('fa-search').addClass('spinner')
+        $.getJSON((RED.settings.httpAdminRoot || '') + 'nrcse/discoverAllZones', function (zones) {
+          $('#node-lookup-zones-icon').removeClass('spinner').addClass('fa-search')
+          const current = $zone.val()
+          $zone.empty()
+          $zone.append($('<option>').val('').text('-- use IP/hostname below --'))
+          $.each(zones, function (i, z) {
+            if (z.value) {
+              $zone.append($('<option>').val(z.value).attr('data-playername', z.playerName || '').text(z.label))
+            }
+          })
+          if (current) { $zone.val(current) }
+          $zone.trigger('change')
+        })
+      })
 
       // playerHostname text field: enter ip or do a discovery and select
       try {
@@ -179,6 +212,18 @@
 <div class="form-tips" id="node-tip-confignode" style="width: auto;">
   <b>Config node</b>: Default name is household. Please use only ONE config node for all nodes.
   Use Node-RED menu item "Configuration Nodes" to remove duplicates.
+</div><br>
+
+<!-- Zone (durable uuid) -->
+<div class="form-row">
+  <label for="node-input-playerUuid" style="width: 30%;"><i class="fa fa-music"></i> Zone</label>
+  <select id="node-input-playerUuid" style="width: 55%;"></select>
+  <button type="button" id="node-lookup-zones" class="red-ui-button"><i id="node-lookup-zones-icon" class="fa fa-search"></i></button>
+</div>
+<input type="hidden" id="node-input-playerName">
+<div class="form-tips">
+  <b>Zone</b> (recommended): address the player by its permanent id so it keeps working
+  after a DHCP/IP change. Click search to discover zones. Leave empty to use the IP/hostname below.
 </div><br>
 
 <!-- SONOS player hostname such such 192.168.178.37-->

--- a/src/sonosevents-selection.js
+++ b/src/sonosevents-selection.js
@@ -72,19 +72,53 @@ module.exports = function (RED) {
         eventsByServices[serviceName][eventName] = i
       }
 
-      // subscribe and handle errors direct
-      subscribeToMultipleEvents(node, player, eventsByServices)
-        .then((port) => { // success, when handler is successfully established
+      // refresh/retry cadence (seconds); default 60
+      const refreshSeconds = (Number(config.refreshSeconds) > 0) ? Number(config.refreshSeconds) : 60
+      let subscribed = false
+
+      // initial subscribe, retrying until the player is reachable so a SID is
+      // always established (RefreshEventSubscriptions is a no-op without one)
+      async function establishSubscription () {
+        try {
+          const port = await subscribeToMultipleEvents(node, player, eventsByServices)
+          subscribed = true
           node.status({ fill: 'green', shape: 'ring', text: `connected: ${port}` })
           node.debug(`port >>${JSON.stringify(port)}`)
-        })
-        .catch((error) => {
+        } catch (error) {
+          subscribed = false
           node.status({ fill: 'red', shape: 'ring', text: 'disconnected: ' + error.message })
           node.debug(`error subscribe>>${JSON.stringify(error, Object.getOwnPropertyNames(error))}`)
-        })
-      
+          node.retryTimer = setTimeout(establishSubscription, refreshSeconds * 1000)
+        }
+      }
+      establishSubscription()
+
+      // watchdog: renew on a tight interval so a stale SID after a player
+      // power-cycle triggers a fresh re-subscribe within refreshSeconds,
+      // instead of waiting for the library's ~10 min renewal timer
+      node.refreshTimer = setInterval(function () {
+        if (!subscribed) return
+        player.RefreshEventSubscriptions()
+          .catch(error => { node.debug(`refresh subscriptions failed >>${error.message}`) })
+      }, refreshSeconds * 1000)
+
+      // any input message forces an immediate re-subscribe
+      node.on('input', function (msg, send, done) {
+        player.RefreshEventSubscriptions()
+          .then(() => {
+            node.status({ fill: 'green', shape: 'dot', text: 'resubscribed' })
+            if (done) done()
+          })
+          .catch(error => {
+            node.status({ fill: 'red', shape: 'ring', text: 'resubscribe failed: ' + error.message })
+            if (done) done(error)
+          })
+      })
+
       // unsubscribe to all, when node is deleted (redeployed does delete)
       node.on('close', function (done) {
+        if (node.refreshTimer) { clearInterval(node.refreshTimer) }
+        if (node.retryTimer) { clearTimeout(node.retryTimer) }
         cancelAllSubscriptions(player, eventsByServices)
           .then(() => {
             debug('nodeOnClose >>all subscriptions canceled')

--- a/src/sonosevents-selection.js
+++ b/src/sonosevents-selection.js
@@ -3,9 +3,9 @@
  * Node create a selection of events.
  *
  * @module selection
- * 
+ *
  * @author Henning Klages
- * 
+ *
  * @since 2021-01-16
 */
 
@@ -13,10 +13,12 @@
 
 const { PACKAGE_PREFIX, REGEX_IP, REGEX_DNS } = require('./Globals.js')
 
+const { discoverIpByUuid } = require('./Discovery.js')
+
 const { isTruthyProperty } = require('./Helper')
 
 const { filterAndImproveServiceData } = require('./Extensions')
-  
+
 const { SonosDevice, SonosEventListener, ServiceEvents } = require('@svrooij/sonos/lib')
 
 const request = require('axios').default
@@ -31,116 +33,128 @@ module.exports = function (RED) {
   /** Create event node notification based on configuration and send messages
    * @param  {object} config current node configuration data
   */
-  
+
   function sonosEventsSelectionNode (config) {
     debug('method >>%s', 'sonosEventsSelectionNode')
     RED.nodes.createNode(this, config)
-   
-    // clear node status, get data from dialog
+
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const node = this
     node.status({})
-    let ipv4Address
-      
-    // async wrap to make it possible to use await dnsPromise
-    (async function () {
+
+    // build {service: {event: outputIndex}} map from the dialog
+    const eventsByServices = {}
+    const subscriptions = config.events
+    for (let i = 0; i < subscriptions.length; i++) {
+      const [serviceName, eventName] = subscriptions[i].fullName.split('.')
+      if (!isTruthyProperty(eventsByServices, [serviceName])) {
+        eventsByServices[serviceName] = {}
+      }
+      eventsByServices[serviceName][eventName] = i
+    }
+
+    const refreshSeconds = (Number(config.refreshSeconds) > 0) ? Number(config.refreshSeconds) : 60
+    let player = null
+    let subscribed = false
+
+    // Resolve the target player to a current ipv4 address.
+    // Preferred: durable uuid -> discover current ip (survives DHCP changes).
+    // Fallback: ipv4 address or DNS name in playerHostname (non-breaking).
+    async function resolveIp () {
+      if (isTruthyProperty(config, ['playerUuid']) && config.playerUuid !== '') {
+        const ip = await discoverIpByUuid(config.playerUuid)
+        if (!ip) throw new Error('player uuid not found on network')
+        return ip
+      }
       if (REGEX_IP.test(config.playerHostname)) {
-        ipv4Address = config.playerHostname // pure ip address
-      } else if (REGEX_DNS.test(config.playerHostname)) { // DNS name to be resolved
-        const ipv4Array = await dnsPromises.resolve4(config.playerHostname) 
-        // dnsPromise returns an array with all data
-        ipv4Address = ipv4Array[0] // converted to ip address
-      } else {
-        debug(`${PACKAGE_PREFIX} ipv4//DNS name >>${config.playerHostname} invalid syntax`)
-        node.status({ fill: 'red', shape: 'ring', text: 'ipv4/DNS name has invalid syntax' })
-        return
+        return config.playerHostname
       }
-      // ipv4Address is a pure ipv4 address and ready to use
-
-      // create new player from input such as 192.168.178.37
-      const player = new SonosDevice(ipv4Address)
-
-      // for each service create the required events with corresponding output index
-      const subscriptions = config.events
-      const eventsByServices = {}
-      //  . as general delimiter!
-      for (let i = 0; i < subscriptions.length; i++) {
-        const [serviceName, eventName] = subscriptions[i].fullName.split('.')
-        if (!isTruthyProperty(eventsByServices, [serviceName])) {
-          eventsByServices[serviceName] = {}
-        }
-        eventsByServices[serviceName][eventName] = i
+      if (REGEX_DNS.test(config.playerHostname)) {
+        const ipv4Array = await dnsPromises.resolve4(config.playerHostname)
+        return ipv4Array[0]
       }
+      throw new Error('no valid player uuid or ipv4/DNS name')
+    }
 
-      // refresh/retry cadence (seconds); default 60
-      const refreshSeconds = (Number(config.refreshSeconds) > 0) ? Number(config.refreshSeconds) : 60
-      let subscribed = false
+    async function subscribeAt (ip) {
+      player = new SonosDevice(ip)
+      await subscribeToMultipleEvents(node, player, eventsByServices)
+    }
 
-      // initial subscribe, retrying until the player is reachable so a SID is
-      // always established (RefreshEventSubscriptions is a no-op without one)
-      async function establishSubscription () {
-        try {
-          const port = await subscribeToMultipleEvents(node, player, eventsByServices)
-          subscribed = true
-          node.status({ fill: 'green', shape: 'ring', text: `connected: ${port}` })
-          node.debug(`port >>${JSON.stringify(port)}`)
-        } catch (error) {
-          subscribed = false
-          node.status({ fill: 'red', shape: 'ring', text: 'disconnected: ' + error.message })
-          node.debug(`error subscribe>>${JSON.stringify(error, Object.getOwnPropertyNames(error))}`)
-          node.retryTimer = setTimeout(establishSubscription, refreshSeconds * 1000)
-        }
+    // initial subscribe, retrying until the player is reachable so a SID is
+    // always established (RefreshEventSubscriptions is a no-op without one)
+    async function establishSubscription () {
+      try {
+        const ip = await resolveIp()
+        await subscribeAt(ip)
+        subscribed = true
+        node.status({ fill: 'green', shape: 'ring', text: `connected: ${player.host}` })
+      } catch (error) {
+        subscribed = false
+        node.status({ fill: 'red', shape: 'ring', text: 'disconnected: ' + error.message })
+        node.debug(`error subscribe>>${JSON.stringify(error, Object.getOwnPropertyNames(error))}`)
+        node.retryTimer = setTimeout(establishSubscription, refreshSeconds * 1000)
       }
-      establishSubscription()
+    }
+    establishSubscription()
 
-      // watchdog: renew on a tight interval so a stale SID after a player
-      // power-cycle triggers a fresh re-subscribe within refreshSeconds,
-      // instead of waiting for the library's ~10 min renewal timer
-      node.refreshTimer = setInterval(function () {
-        if (!subscribed) return
-        player.RefreshEventSubscriptions()
-          .catch(error => { node.debug(`refresh subscriptions failed >>${error.message}`) })
-      }, refreshSeconds * 1000)
-
-      // any input message forces an immediate re-subscribe
-      node.on('input', function (msg, send, done) {
-        player.RefreshEventSubscriptions()
-          .then(() => {
-            node.status({ fill: 'green', shape: 'dot', text: 'resubscribed' })
-            if (done) done()
-          })
-          .catch(error => {
-            node.status({ fill: 'red', shape: 'ring', text: 'resubscribe failed: ' + error.message })
-            if (done) done(error)
-          })
-      })
-
-      // unsubscribe to all, when node is deleted (redeployed does delete)
-      node.on('close', function (done) {
-        if (node.refreshTimer) { clearInterval(node.refreshTimer) }
-        if (node.retryTimer) { clearTimeout(node.retryTimer) }
-        cancelAllSubscriptions(player, eventsByServices)
-          .then(() => {
-            debug('nodeOnClose >>all subscriptions canceled')
-            done()
-          })
-          .catch(error => {
-            debug(`nodeOnClose error during cancel subscriptions >>
-            ${JSON.stringify(error, Object.getOwnPropertyNames(error))}`)
-            done(error)
-          })
-      })
- 
-    })() // end of async wrapper for DNS
-      .catch((err) => {
-        debug('Could not resolve DNS name - error message >>%',
-          JSON.stringify(err, Object.getOwnPropertyNames(err)))
-        node.status({
-          fill: 'red', shape: 'ring',
-          text: 'Could not resolve DNS name >>' + config.playerHostname
+    // watchdog: renew on a tight interval so a stale SID after a player
+    // power-cycle re-subscribes within refreshSeconds. If the renew fails the
+    // player may be gone or moved to a new ip - re-resolve (by uuid) and, if the
+    // address changed, rebuild the device and re-subscribe at the new ip.
+    node.refreshTimer = setInterval(function () {
+      if (!subscribed || !player) return
+      player.RefreshEventSubscriptions()
+        .catch(async () => {
+          try {
+            const ip = await resolveIp()
+            if (ip && ip !== player.host) {
+              await cancelAllSubscriptions(player, eventsByServices)
+              await subscribeAt(ip)
+              node.status({ fill: 'green', shape: 'ring', text: `reconnected: ${player.host}` })
+            }
+          } catch (error) {
+            node.debug(`rediscover failed >>${error.message}`)
+          }
         })
-      })
-    
+    }, refreshSeconds * 1000)
+
+    // any input message forces an immediate re-resolve + re-subscribe
+    node.on('input', function (msg, send, done) {
+      (async function () {
+        const ip = await resolveIp()
+        if (!player || ip !== player.host) {
+          if (player) await cancelAllSubscriptions(player, eventsByServices)
+          await subscribeAt(ip)
+        } else {
+          await player.RefreshEventSubscriptions()
+        }
+        subscribed = true
+        node.status({ fill: 'green', shape: 'dot', text: `resubscribed: ${player.host}` })
+      })()
+        .then(() => { if (done) done() })
+        .catch(error => {
+          node.status({ fill: 'red', shape: 'ring', text: 'resubscribe failed: ' + error.message })
+          if (done) done(error)
+        })
+    })
+
+    // unsubscribe to all, when node is deleted (redeployed does delete)
+    node.on('close', function (done) {
+      if (node.refreshTimer) { clearInterval(node.refreshTimer) }
+      if (node.retryTimer) { clearTimeout(node.retryTimer) }
+      if (!player) { done(); return }
+      cancelAllSubscriptions(player, eventsByServices)
+        .then(() => {
+          debug('nodeOnClose >>all subscriptions canceled')
+          done()
+        })
+        .catch(error => {
+          debug(`nodeOnClose error during cancel subscriptions >>${JSON.stringify(error, Object.getOwnPropertyNames(error))}`)
+          done(error)
+        })
+    })
+
     return true
   }
 
@@ -150,17 +164,17 @@ module.exports = function (RED) {
 /** Subscribe to multiple services, filter properties and send messages for a given player.
  * @param {object} node current node
  * @param {object} player sonos-ts player object
- * @param {object} eventsByServices such as 
+ * @param {object} eventsByServices such as
  *                  "RenderingControlService":{"raw":0}} 0 stands for output index
  *
  * @returns {promise<string>} host:port OK
- * 
+ *
  * @throws errors isTruthyPropertyStringNotEmpty, isTruthyProperty
  */
 async function subscribeToMultipleEvents (node, player, eventsByServices) {
   debug('method >>%s', 'asyncSubscribeToMultipleEvents')
   // general definition for this node
-  let errorCount = 0 
+  let errorCount = 0
   const serviceArray = Object.keys(eventsByServices)
 
   // get number of events = number of outputs
@@ -172,7 +186,7 @@ async function subscribeToMultipleEvents (node, player, eventsByServices) {
   let capabilities = []
   let response
   try {
-    response = await request.get(`http://${player.host}:${player.port}/info`, { timeout: 4000 })  
+    response = await request.get(`http://${player.host}:${player.port}/info`, { timeout: 4000 })
   } catch (error) {
     debug('invalid player - http request >>%s', JSON.stringify(error.message))
     // TODO check ECONNREFUSED
@@ -194,11 +208,11 @@ async function subscribeToMultipleEvents (node, player, eventsByServices) {
     && !capabilities.includes('LINE_IN')) {
     throw new Error('lineInConnected not possible')
   }
-  
+
   // what port, host ...
   debug('event listener status >>%s',
     JSON.stringify(SonosEventListener.DefaultInstance.GetStatus()))
-  
+
   // subscribe to the specified services/events
   serviceArray.forEach(async function (serviceName) {
     // const response = await ... does not provide any relevant information
@@ -206,7 +220,7 @@ async function subscribeToMultipleEvents (node, player, eventsByServices) {
       sendServiceMsgs.bind(this, serviceName, eventsByServices[serviceName], outputs))
     debug('subscribed to >>%s', serviceName)
   })
-  
+
   return SonosEventListener.DefaultInstance.GetStatus().port
 
   // .............. sendMsg functions ...............
@@ -215,12 +229,12 @@ async function subscribeToMultipleEvents (node, player, eventsByServices) {
 
   async function sendServiceMsgs (serviceName, mapEventToOutput, outputs, raw) {
     debug('new event >>', serviceName)
-   
+
     try {
       // define msg s
       const topicPrefix = `${player.host}/${serviceName}/`
       const improved = await filterAndImproveServiceData(serviceName, raw)
-      
+
       const eventNames = Object.keys(mapEventToOutput)
       eventNames.forEach(eventName => {
         if (isTruthyProperty(mapEventToOutput, [eventName])) {
@@ -233,12 +247,12 @@ async function subscribeToMultipleEvents (node, player, eventsByServices) {
           } else {
             // we have to remove null events
             if (improved[eventName] !== null) {
-              const payload = improved[eventName]   
+              const payload = improved[eventName]
               msg[mapEventToOutput[eventName]] = { payload, topic, raw }
               node.send(msg)
             }
           }
-        }  
+        }
       })
     } catch (error) {
       errorCount++
@@ -249,7 +263,7 @@ async function subscribeToMultipleEvents (node, player, eventsByServices) {
 }
 
 async function cancelAllSubscriptions (player, eventsByServices) {
-  
+
   const serviceArray = Object.keys(eventsByServices)
   serviceArray.forEach(async function (serviceName) {
     await player[serviceName].Events.removeAllListeners(ServiceEvents.ServiceEvent)


### PR DESCRIPTION
## Problem
Fixes the long-standing loss of events after a player power-cycle — acknowledged in #13 ("the subscription gets lost and will never be restored"), and related to #16 and #18. Two root causes:
1. The selection node subscribes once at startup with no recovery if the subscription later fails.
2. Addressing is by IP/DNS, so a post-reboot DHCP change leaves the configured address pointing at nothing.

## Fix (non-breaking — IP/hostname still works exactly as before)
1. **Resilient subscriptions:** retry the initial subscribe until a SID is established; a watchdog renews on a configurable interval (default 60s) so a stale-SID renewal triggers a fresh re-subscribe promptly (instead of waiting for the library's ~10-min timer); a node `input` forces an immediate re-subscribe.
2. **Durable UUID addressing:** the config dialog can discover and list zones and persist the player's RINCON UUID; at runtime the UUID is resolved to the current IP via SSDP + ZoneGroupTopology, and on a failed renewal the node re-discovers and rebuilds the device at the new IP. Adds admin endpoint `/nrcse/discoverAllZones`.

## Testing
Verified on real hardware: power-cycling the player — including a DHCP IP change — now auto-recovers within the refresh interval; previously it stayed dead until redeploy.

## Notes
- Two logical commits (subscription resilience, then UUID discovery); happy to split into separate PRs.
- I see the package is in maintenance-freeze (#17) — opening as a draft in case it's useful to you or others; no obligation.